### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,7 @@ insert_final_newline = false
 
 # Organize usings
 dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = false
+dotnet_sort_system_directives_first = true
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent


### PR DESCRIPTION
See: https://limbo-works.slack.com/archives/CRUT5SJLX/p1642508800036400

The various tools we may use for formatting our C# does not all follow the `dotnet_sort_system_directives_first` rule. For one, Visual Studio seems to add System namespaces before other imports regardless of this setting, and pressing `CTRL + K` + `CTRL + D` to format a given file does not change the order of the imports.

Running `dotnet format` - does follow the `dotnet_sort_system_directives_first` - so since our .editorconfig file has this setting set to `false`, running `dotnet format` will sort the imports 100% alphabetically.

To align the various tools, it would be best to have the `dotnet_sort_system_directives_first` setting set to `true` (hence this PR).