### PR TITLE
Only private fields should have an underscore prefix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -196,11 +196,15 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-dotnet_naming_rule.instance_fields_should_be_camel_case.severity = suggestion
-dotnet_naming_rule.instance_fields_should_be_camel_case.symbols = instance_fields
-dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_style
+# Define what we will treat as private fields
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
 
-dotnet_naming_symbols.instance_fields.applicable_kinds = field
+# Define rule that something must begin with an underscore and be in camel case
+dotnet_naming_style.require_underscore_prefix_and_camel_case.required_prefix = _
+dotnet_naming_style.require_underscore_prefix_and_camel_case.capitalization = camel_case
 
-dotnet_naming_style.instance_field_style.capitalization = camel_case
-dotnet_naming_style.instance_field_style.required_prefix = _
+# Apply our rule to private fields
+dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_case.style = require_underscore_prefix_and_camel_case
+dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_case.severity = warning


### PR DESCRIPTION
With #2, we tried to set a requirement for an underscore prefix for private fields, but this ended up applying to all fields regardless of visibility :(

![image](https://user-images.githubusercontent.com/3634580/150377135-3f6ddb17-4b21-4611-8313-979814ff2baa.png)

At least to the extent that I've tested the changes in this commit, the new rules seem to only apply to private fields like we wanted it to, and then not affect public fields 😎