### PR TITLE
Added rule to not prefer primary constructors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -214,3 +214,6 @@ dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_cas
 
 # Prefer file-scoped namespace declarations
 csharp_style_namespace_declarations = file_scoped:warning
+
+# Don't prefer or suggest primary constructors
+csharp_style_prefer_primary_constructors = false


### PR DESCRIPTION
As discussed with @tnielsenskybruddk, we don't really like the syntax around primary constructors, and as a result, I'm adding the `csharp_style_prefer_primary_constructors = false` to our `.editorconfig` file.